### PR TITLE
Iss93 json unicode bug

### DIFF
--- a/digiarch/data.py
+++ b/digiarch/data.py
@@ -50,6 +50,7 @@ class DataJSONEncoder(json.JSONEncoder):
 
     def default(self, obj: object) -> Any:
         """Overrides the JSONEncoder default.
+
         Parameters
         ----------
         obj : object
@@ -99,11 +100,8 @@ def load_json_list(data_file: str) -> List[dict]:
 
 def get_fileinfo_list(data_file: str) -> List[FileInfo]:
     # Read file info from data file
-    data: List[dict] = tqdm.tqdm(
-        load_json_list(data_file), desc="Reading file information"
-    )
+    data: List[dict] = load_json_list(data_file)
+
     # Load file info into list
-    info: List[FileInfo] = tqdm.tqdm(
-        [FileInfo.from_dict(d) for d in data], desc="Loading file information"
-    )
+    info: List[FileInfo] = [FileInfo.from_dict(d) for d in data]
     return info

--- a/digiarch/data.py
+++ b/digiarch/data.py
@@ -9,7 +9,6 @@ Digital Archive.
 import dataclasses
 import dacite
 import json
-import tqdm
 from typing import Any, List
 
 # -----------------------------------------------------------------------------

--- a/digiarch/data.py
+++ b/digiarch/data.py
@@ -16,6 +16,9 @@ from typing import Any, List
 # Classes
 # -----------------------------------------------------------------------------
 
+# File Info
+# --------------------
+
 
 @dataclasses.dataclass
 class FileInfo:
@@ -32,27 +35,60 @@ class FileInfo:
         """Avoid having to import dataclasses all the time."""
         return dataclasses.asdict(self)
 
-    def to_json(self) -> str:
-        """Return json dump using
-        :class:`~digiarch.data.DataclassEncoder`"""
-        return json.dumps(self, default=encode_dataclass)
-
     @staticmethod
     def from_dict(data: dict) -> Any:
         return dacite.from_dict(data_class=FileInfo, data=data)
 
 
+# Utility
+# --------------------
+
+
+class DataJSONEncoder(json.JSONEncoder):
+    """DataJSONEncoder subclasses JSONEncoder in order to handle
+    encoding of dataclasses."""
+
+    def default(self, obj: object) -> Any:
+        """Overrides the JSONEncoder default.
+        Parameters
+        ----------
+        obj : object
+            Object to encode.
+        Returns
+        -------
+        dataclasses.asdict(obj) : dict
+            If the object given is a data class, return it as a dict.
+        super().default(obj) : Any
+            If the object is not a data class, use JSONEncoder's default and
+            let it handle any exception that might occur.
+        """
+        if dataclasses.is_dataclass(obj):
+            return dataclasses.asdict(obj)
+        return super().default(obj)
+
+
 # -----------------------------------------------------------------------------
 # Function Definitions
 # -----------------------------------------------------------------------------
-def encode_dataclass(data_cls: object) -> dict:
-    try:
-        return dataclasses.asdict(data_cls)
-    except TypeError:
-        type_name = type(data_cls)
-        raise TypeError(
-            f"Object of type {type_name} is not serializable with this default"
-        )
+
+
+def dump_file(data: object, file: str) -> None:
+    """Dumps JSON files given data and a file path
+    using :class:`~digiarch.data.DataJSONEncoder` as encoder.
+    Output uses indent = 4 to get pretty and readable files.
+    `ensure_ascii` is set to `False` so we can get our beautiful Danish
+    letters in the output.
+
+    Parameters
+    ----------
+    data : object
+        The data to dump to the JSON file.
+    dump_file: str
+        Path to the file in which to dump JSON data.
+    """
+
+    with open(file, "w+") as f:
+        json.dump(data, f, indent=4, cls=DataJSONEncoder, ensure_ascii=False)
 
 
 def load_json_list(data_file: str) -> List[dict]:

--- a/digiarch/utils/path_utils.py
+++ b/digiarch/utils/path_utils.py
@@ -5,9 +5,8 @@
 # Imports
 # -----------------------------------------------------------------------------
 import os
-import json
 from tqdm import tqdm
-from digiarch.data import FileInfo, encode_dataclass
+from digiarch.data import FileInfo, dump_file
 from typing import List, Tuple
 
 # -----------------------------------------------------------------------------
@@ -52,8 +51,7 @@ def explore_dir(path: str, main_dir: str, save_file: str) -> None:
 
     if not main_folders:
         # Path is empty, write empty file and return
-        with open(save_file, "w") as file:
-            file.write(json.dumps(""))
+        dump_file(data="", file=save_file)
         return
 
     # Traverse given path, collect results.
@@ -75,5 +73,4 @@ def explore_dir(path: str, main_dir: str, save_file: str) -> None:
             dir_info.append(info)
 
     # Save results
-    with open(save_file, "w") as file:
-        file.write(json.dumps(dir_info, default=encode_dataclass, indent=4))
+    dump_file(data=dir_info, file=save_file)

--- a/tests/identify/test_reports.py
+++ b/tests/identify/test_reports.py
@@ -1,13 +1,11 @@
-import json
 import os
 from typing import List
 from digiarch.identify.reports import report_results
-from digiarch.data import FileInfo, encode_dataclass
+from digiarch.data import FileInfo, dump_file
 
 
 def write_test_file(temp_dir, data_file, dir_info):
-    with open(data_file, "w") as file:
-        file.write(json.dumps(dir_info, default=encode_dataclass, indent=4))
+    dump_file(dir_info, data_file)
 
 
 class TestReportResults:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from digiarch.data import FileInfo, encode_dataclass
+from digiarch.data import FileInfo, DataJSONEncoder
 
 
 @pytest.fixture
@@ -18,24 +18,11 @@ def make_json_fail():
     return FailJSON
 
 
-class TestFileInfo:
-    def test_to_json(self, file_info):
-        file_info_json = file_info.to_json()
-        assert json.loads(file_info_json) == {
-            "name": "test.txt",
-            "ext": ".txt",
-            "is_empty_sub": False,
-            "path": "/root",
-            "mime_type": "",
-            "guessed_ext": "",
-        }
-
-
 class TestJSONEncode:
     def test_with_valid_input(self):
-        data = json.dumps(123, default=encode_dataclass)
+        data = json.dumps(123, cls=DataJSONEncoder)
         assert json.loads(data) == 123
 
     def test_with_invalid_input(self, make_json_fail):
         with pytest.raises(TypeError):
-            assert json.dumps(make_json_fail, default=encode_dataclass)
+            assert json.dumps(make_json_fail, cls=DataJSONEncoder)


### PR DESCRIPTION
This fixes the unicode bug in #93 by introducing a function dump_file, which dumps JSON data to a file with pre-specified parameters. In particular, we pass `ensure_ascii=False` which solves the issue.
`JSONEncoder` is now subclassed to handle data classes instead of the old solution. This required updates of tests using the old `encode_dataclass` function as default.