### PR TITLE
Updated signature for tnef files.

### DIFF
--- a/digiarch/core/custom_sigs.json
+++ b/digiarch/core/custom_sigs.json
@@ -77,9 +77,22 @@
         "puid": "aca-fmt/9",
         "signature": "Microsoft email attachments archive (winmail)",
         "extension": ".dat"
-    }
+    },
 
-    ,
+
+    {
+        "bof": "(?i)010690080004000000000001000100010790060008000000E404000000000000E800010",
+        "puid": "aca-fmt/9",
+        "signature": "Microsoft email attachments archive (winmail)",
+        "extension": ".dat"
+    },
+
+    {
+        "bof": "(?i)^789F3E22",
+        "puid": "aca-fmt/9",
+        "signature": "Microsoft email attachments archive (winmail)",
+        "extension": ".dat"
+    },
 
     {
         "bof": "(?i)41636365737356657273696F6E.{0,1024}30362E",


### PR DESCRIPTION
# Description.
Added 2 new signatures for tnef files. The first one is the common substring of the original signature found in the unidentified winmail.dat file. The second is a byte header string which also seems to identify all the tnef files.

# Note:
In theory we only need the last signature: `(?i)^789F3E22`, since it is found in all the winmail files and must be a byte header for the tnef file format. However, since it is rather short, I have included the 2 other signatures. We should discuss if these should be deleted.