### PR TITLE
576 implementation make image is preservable threadssafe and update its test to take care of this

### DIFF
--- a/digiarch/core/identify_files.py
+++ b/digiarch/core/identify_files.py
@@ -5,7 +5,6 @@
 # Imports
 # -----------------------------------------------------------------------------
 import json
-import pdb
 import re
 import subprocess
 import os
@@ -13,10 +12,9 @@ import logging as log
 from logging import Logger
 from functools import partial
 from pathlib import Path
-from typing import Any, Tuple, Union
+from typing import Any, Tuple
 from typing import Dict
 from typing import List
-from threading import Lock
 
 import PIL
 
@@ -207,7 +205,7 @@ def is_preservable(file: ArchiveFile) -> Tuple[bool, Any]:
         "x-fmt/391",
     ]
     if file.puid in image_format_codes:
-        if image_is_preservable(file, lock=None):
+        if image_is_preservable(file):
             return (True, None)
         else:
             return (False, "Image contains less than 20000 pixels.")
@@ -220,21 +218,24 @@ def is_preservable(file: ArchiveFile) -> Tuple[bool, Any]:
         return (True, None)
 
 
-def open_image_file(file_path) -> bool:
+def open_image_file(file_path: Path) -> bool:
     with Image.open(file_path) as im:
-            width, height = im.size
-            pixel_amount = width * height
-            if pixel_amount < 20000:
-                return False
-            else:
-                return True
+        width, height = im.size
+        pixel_amount = width * height
+        if pixel_amount < 20000:
+            return False
+        else:
+            return True
 
 
-
-def image_is_preservable(file: ArchiveFile, lock: Union[Lock, None] = None) -> bool:
-    # set up a log file to keep track of decompresion bombs  
-    logger: Logger = log.getLogger('image_is_preservable')
-    file_handler = log.FileHandler("pillow_decompressionbomb.log", mode="w", encoding="utf-8")
+def image_is_preservable(
+    file: ArchiveFile,
+) -> bool:
+    # set up a log file to keep track of decompresion bombs
+    logger: Logger = log.getLogger("image_is_preservable")
+    file_handler = log.FileHandler(
+        "pillow_decompressionbomb.log", mode="w", encoding="utf-8"
+    )
     log_fmt = log.Formatter(
         fmt="%(asctime)s - %(levelname)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
@@ -252,18 +253,18 @@ def image_is_preservable(file: ArchiveFile, lock: Union[Lock, None] = None) -> b
         print(f"PIL could not open the file: {file.relative_path}")
         return True
     except Image.DecompressionBombWarning:
-        if lock:
-            with lock:
-                logger.warning("The file {} threw a decompresionbomb warning".format(file.relative_path))
-        else:
-            logger.warning("The file {} threw a decompresionbomb warning".format(file.relative_path))
+        logger.warning(
+            "The file {} threw a decompresionbomb warning".format(
+                file.relative_path
+            )
+        )
         return True
     except Image.DecompressionBombError:
-        if lock:
-            with lock:
-                logger.error("The file {} threw a decompresionbomb error".format(file.relative_path))
-        else:
-            logger.error("The file {} threw a decompresionbomb error".format(file.relative_path))
+        logger.error(
+            "The file {} threw a decompresionbomb error".format(
+                file.relative_path
+            )
+        )
         return True
 
 

--- a/digiarch/core/identify_files.py
+++ b/digiarch/core/identify_files.py
@@ -260,10 +260,12 @@ def image_is_preservable(
     try:
         result: bool = open_image_file(file_path)
         lock.release()
+        del log.Logger.manager.loggerDict["image_is_preservable"]
         return result
     except PIL.UnidentifiedImageError:
         print(f"PIL could not open the file: {file.relative_path}")
         lock.release()
+        del log.Logger.manager.loggerDict["image_is_preservable"]
         return True
     except Image.DecompressionBombWarning:
         logger.warning(
@@ -272,6 +274,7 @@ def image_is_preservable(
             )
         )
         lock.release()
+        del log.Logger.manager.loggerDict["image_is_preservable"]
         return True
     except Image.DecompressionBombError:
         logger.error(
@@ -280,6 +283,7 @@ def image_is_preservable(
             )
         )
         lock.release()
+        del log.Logger.manager.loggerDict["image_is_preservable"]
         return True
 
 

--- a/digiarch/core/identify_files.py
+++ b/digiarch/core/identify_files.py
@@ -233,7 +233,7 @@ def open_image_file(file_path: Path) -> bool:
 def setup_logger() -> Logger:
     logger: Logger = log.getLogger("image_is_preservable")
     file_handler = log.FileHandler(
-        "pillow_decompressionbomb.log", mode="w", encoding="utf-8"
+        "pillow_decompressionbomb.log", mode="a", encoding="utf-8"
     )
     log_fmt = log.Formatter(
         fmt="%(asctime)s - %(levelname)s: %(message)s",

--- a/digiarch/database/db.py
+++ b/digiarch/database/db.py
@@ -155,7 +155,7 @@ class FileDB(Database):
         query = self.files.select()
         rows = await self.fetch_all(query)
         try:
-            files = parse_obj_as(List[ArchiveFile], rows)
+            files: List[ArchiveFile] = parse_obj_as(List[ArchiveFile], rows)
         except ValidationError:
             raise FileParseError(
                 """Failed to parse files as ArchiveFiles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,5 @@ build-backend = "poetry.masonry.api"
 
 [tool.pytest.ini_options]
 asyncio_mode="strict"
+pythonpath = ["."]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,12 @@ def temp_dir(tmpdir_factory):
     temp_dir.mkdir(exist_ok=True)
     return temp_dir
 
+@pytest.fixture
+def pillow_log():
+    path_to_file: Path = 'pillow_decompressionbomb.log'
+    yield path_to_file
+    os.remove(path_to_file)
+
 
 @pytest.fixture
 def main_dir(temp_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,12 +25,6 @@ def temp_dir(tmpdir_factory):
     temp_dir.mkdir(exist_ok=True)
     return temp_dir
 
-@pytest.fixture
-def pillow_log():
-    path_to_file: Path = 'pillow_decompressionbomb.log'
-    yield path_to_file
-    os.remove(path_to_file)
-
 
 @pytest.fixture
 def main_dir(temp_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,12 @@
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
+from logging import Logger
+from threading import Lock
 from typing import Tuple, Union
 from digiarch.core.ArchiveFileRel import ArchiveFile
 from pathlib import Path
+from digiarch.core.identify_files import setup_logger
 import pytest
 import os
 import png
@@ -173,3 +176,15 @@ def python_wiki_binary_file(python_wiki):
         is_binary=True,
     )
     return larger_binary_file
+
+
+@pytest.fixture
+def lock():
+    lock: Lock = Lock()
+    yield lock
+
+
+@pytest.fixture
+def log():
+    log: Logger = setup_logger()
+    yield log

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,3 +188,10 @@ def lock():
 def log():
     log: Logger = setup_logger()
     yield log
+
+
+@pytest.fixture(scope="session", autouse=True)
+def destroy_log():
+    yield
+    path_to_log: Path = Path("pillow_decompressionbomb.log")
+    os.remove(path_to_log)

--- a/tests/core/test_identify_files.py
+++ b/tests/core/test_identify_files.py
@@ -327,10 +327,17 @@ class TestIsPreservable:
         )
 
         image_is_preservable(binary_file, lock, logger=log)
+        # The assertions are ugly and not best practice. They are used to
+        # check multiple lines of the file, and if one of them contains the
+        # warning then the test should assert True
         with open(pathToFile, mode="r", encoding="utf-8") as file:
-            line = file.readline()
-            assert (
-                "WARNING: The file image_file.png threw a"
-                " decompresionbomb warning\n" in line
-            )
-        file.close()
+            for line in file.readlines():
+                if (
+                    "WARNING: The file image_file.png threw a "
+                    "decompresionbomb warning\n" in line
+                ):
+                    assert True
+                    return
+                else:
+                    continue
+            assert False


### PR DESCRIPTION
Fixed the following:
- Made image_is_preservable threadsafe with a lock, to make sure multiple threads does not write to the .log file 
- Deletes the Logger object and its assosiated Handler when the functions returns. This ensures that there arent multiple Handlers trying to write to the same file, there by making unintended behaviour
- Deletes the .log file when all test have run through a fixture.